### PR TITLE
Fixes scope bleed

### DIFF
--- a/lib/micro-enum.js
+++ b/lib/micro-enum.js
@@ -1,1 +1,1 @@
-Enum=function(){v=arguments;s={all:[],keys:v};for(i=v.length;i--;)s[v[i]]=s.all[i]=i;return s}
+Enum=function(){let v=arguments,s={all:[],keys:v};for(let i=v.length;i--;)s[v[i]]=s.all[i]=i;return s;}


### PR DESCRIPTION
The function erroneously bleeds `s`, `v`, and `i` into the global object. This fix uses the `let` statement to put a stop to that.